### PR TITLE
Updated to version 1.0.5 to fix issue 29

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ version := "1.0.5"
 
 scalaVersion := "2.11.6"
 
-mainClass in (Compile, run) := Some("runtime.InvivogenTDSPrinter")
+mainClass in (Compile, run) := Some("InvivogenTDSPrinter")
 
 libraryDependencies += "org.scala-lang.modules" % "scala-xml_2.11" % "1.0.5"
 libraryDependencies += "org.ccil.cowan.tagsoup" % "tagsoup" % "1.2.1"

--- a/src/main/scala/InvivogenTDSPrinter.scala
+++ b/src/main/scala/InvivogenTDSPrinter.scala
@@ -29,13 +29,13 @@ object InvivogenTDSPrinter {
    *  @return A mapping from product id to number of orders.
    */
   def getOrders(orderFile: String): Map[String, Int] = {
-    val orders = Source.fromFile(orderFile).getLines()
+    val orders = Source.fromFile(orderFile).getLines().toList
 
     val res = for (order <- orders if order.trim.nonEmpty) yield {
       val id :: numCopies :: _ = order.split(",").map(_.trim.replace("\"", "")).toList
       id -> numCopies.toInt
     }
-    res.filter(_._2 > 0).toMap  // Only return the orders with 1 or more to-be-printed pdf
+    res.filter(_._2 > 0).groupBy(_._1).mapValues(_.map(_._2).sum)  // Only return the orders with 1 or more to-be-printed pdf
   }
   
   /** Get all web adresses for all existing TDSs.


### PR DESCRIPTION
Update to version 1.0.5 to fix issue #29. 
The print code is reverted back to what was used previously (more testing is required here).
  