### PR TITLE
Image

### DIFF
--- a/Order.csv
+++ b/Order.csv
@@ -1,1 +1,2 @@
 pfuse-hg1fc2,1
+pUNO1-hCTLA4,1

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 name := "InvivogenTDSPrinter"
-version := "1.0.5"
+version := "1.0.6"
 
 scalaVersion := "2.11.6"
 

--- a/run.bat
+++ b/run.bat
@@ -1,1 +1,1 @@
-java -jar InvivogenTDSPrinter-assembly-1.0.5.jar & pause
+java -jar InvivogenTDSPrinter-assembly-1.0.6.jar & pause

--- a/run.bat
+++ b/run.bat
@@ -1,1 +1,1 @@
-java -jar InvivogenTDSPrinter-assembly-1.0.5.jar & pause
+java -Xmx256m -jar InvivogenTDSPrinter-assembly-1.0.5.jar & pause

--- a/run.bat
+++ b/run.bat
@@ -1,1 +1,1 @@
-java -jar InvivogenTDSPrinter-assembly-1.0.6.jar & pause
+java -Xmx512m -jar InvivogenTDSPrinter-assembly-1.0.6.jar & pause

--- a/run.bat
+++ b/run.bat
@@ -1,1 +1,1 @@
-java -Xmx512m -jar InvivogenTDSPrinter-assembly-1.0.6.jar & pause
+java -Xmx1024m -jar InvivogenTDSPrinter-assembly-1.0.6.jar & pause

--- a/src/main/scala/Html.scala
+++ b/src/main/scala/Html.scala
@@ -26,10 +26,10 @@ object Html {
     load(new sax.InputSource(urlc.getInputStream()))
   }
 
-  /** Parses an XML Node to find the pdf documents.
+  /** Parses an XML Node to find the pdf document for the specified product id.
    *
    *  @param node the XML node to search
-   *  @return all pdf documents meeting the requirements (TDS and MSDS).
+   *  @return the pdf document meeting the requirements; a single TDS link.
    */
   def findPDF(node: Node, id: String) : String = {
     val pdfs = (node \\ "ul").filter(_.attribute("class").getOrElse("").toString == ("liste-pdf")).head
@@ -40,14 +40,15 @@ object Html {
     }
 
     // Check so the id is in the text and only take the first (the TDS)
-    val tds = textLinks.filter{case (text, link) => textContains(text, id)}.head
-    
+    val tds = textLinks.filter{case (text, _) => textContains(text, id)}.head
+
     // In rare cases the TDS does not contain the id while the MSDS does
-    // In this case, there will not be multiple TDS documents for the same product page
-    if (tds._1.startswith("MSDS")) {
-      textLinks.filter{case (text, link) => textContains(text, "TDS")}.head._2
+    // there will not be multiple TDS documents for the same product page in this scenario
+    if (!tds._2.contains("TDS")) {
+      println("-- No specific product TDS found, downloading product family TDS")
+      textLinks.filter{case (_, link) => textContains(link, "TDS")}.head._2
     } else {
-      tds._2  
+      tds._2
     }
   }
 

--- a/src/main/scala/Html.scala
+++ b/src/main/scala/Html.scala
@@ -39,10 +39,16 @@ object Html {
       text.toLowerCase.replaceAll("-|_|\\s","").contains(id.toLowerCase.replaceAll("-|_|\\s",""))
     }
 
-    // Check so the id is in the text
-    textLinks.filter{case (text, link) => textContains(text, id)}
-      .map(_._2)
-      .head // Only take the TDS, ignore the MDMS
+    // Check so the id is in the text and only take the first (the TDS)
+    val tds = textLinks.filter{case (text, link) => textContains(text, id)}.head
+    
+    // In rare cases the TDS does not contain the id while the MSDS does
+    // In this case, there will not be multiple TDS documents for the same product page
+    if (tds._1.startswith("MSDS")) {
+      textLinks.filter{case (text, link) => textContains(text, "TDS")}.head._2
+    } else {
+      tds._2  
+    }
   }
 
   /** Downloads a pdf document.

--- a/src/main/scala/InvivogenTDSPrinter.scala
+++ b/src/main/scala/InvivogenTDSPrinter.scala
@@ -33,7 +33,7 @@ object InvivogenTDSPrinter {
 
     val res = for (order <- orders if order.trim.nonEmpty) yield {
       val id :: numCopies :: _ = order.split(",").map(_.trim.replace("\"", "")).toList
-      id -> numCopies.toInt
+      id.toLowerCase -> numCopies.toInt
     }
     res.filter(_._2 > 0).groupBy(_._1).mapValues(_.map(_._2).sum)  // Only return the orders with 1 or more to-be-printed pdf
   }
@@ -49,7 +49,7 @@ object InvivogenTDSPrinter {
 
     val res = for (idLink <- idLinks if idLink.trim.nonEmpty) yield {
       val id :: link :: _ = idLink.split(",").map(_.trim).toList
-      id -> link
+      id.toLowerCase -> link
     }
     res.toMap
   }

--- a/src/main/scala/InvivogenTDSPrinter.scala
+++ b/src/main/scala/InvivogenTDSPrinter.scala
@@ -5,7 +5,7 @@ import scala.io.Source
 object InvivogenTDSPrinter {
 
   /** Main method, no arguments necessary */
-  def main(args: Array[String]) = {
+  def main(args: Array[String]): Unit = {
     val linkFile    = "ProductLinks.csv"
     val orderFile   = "Order.csv"
     val baseAdress  = "http://invivogen.com/"
@@ -131,7 +131,7 @@ object InvivogenTDSPrinter {
       ||   Invivogen TDS Printer   |
       ||                           |
       |-----------------------------
-      || version: 1.0.5            |
+      || version: 1.0.6            |
       || author : shaido987        |
       || source : @github.com      |
       |-----------------------------

--- a/src/main/scala/Printer.scala
+++ b/src/main/scala/Printer.scala
@@ -52,7 +52,6 @@ object Printer {
     attr.add(Chromaticity.COLOR)
 
     job.print(attr)
-
     pdf.close()
   }
 
@@ -71,15 +70,10 @@ object Printer {
     val pdf = PDDocument.load(file)
     val pdfRenderer = new PDFRenderer(pdf)
 
-    val bims = for (page <- 0 until pdf.getNumberOfPages) yield {
-      pdfRenderer.renderImageWithDPI(page, 500, ImageType.RGB)
-    }
-
     val doc = new PDDocument()
     val pageBox = pdf.getPage(0).getCropBox
-    for ((bim, index) <- bims.zipWithIndex) {
-      //Save image as png test
-      //ImageIOUtil.writeImage(bim, file.getName.dropRight(4) + "-" + (index+1) + ".png", 300)
+    for (orgPage <- 0 until pdf.getNumberOfPages) {
+      val bim = pdfRenderer.renderImageWithDPI(orgPage, 300, ImageType.RGB)
 
       val page = new PDPage(pageBox)
       doc.addPage(page)
@@ -90,9 +84,9 @@ object Printer {
       contentStream.drawImage(pdImageXObject, 0, 0, pageBox.getWidth, pageBox.getHeight)
       contentStream.close()
     }
-    // Save finished pdf test
-    //doc.save("test.pdf")
+    pdf.close()
 
+    // Print the new pdf
     printPDF(doc, file.getName, numCopies)
   }
   
@@ -115,7 +109,7 @@ object Printer {
   def printOrders(dir: String, orders: Map[String, Int]): Unit = {
     println("-----------------------------")
     println("Starting to print")
-    for (((id, numCopies), index) <- orders.zipWithIndex) {
+    for (((id, numCopies), index) <- orders.toSeq.zipWithIndex) {
       println(s"${index+1}/${orders.size}\t$id")
       
       val file = new File(dir + id + ".pdf")

--- a/src/main/scala/Printer.scala
+++ b/src/main/scala/Printer.scala
@@ -84,7 +84,7 @@ object Printer {
       
       // Second bool is compression. Remove if bad quality
       val contentStream = new PDPageContentStream(doc, page, PDPageContentStream.AppendMode.OVERWRITE, true)
-      contentStream.drawImage(pdImageXObject, 0, 0)
+      contentStream.drawImage(pdImageXObject, 0, page.getCropBox().getHeight())
       contentStream.close()
     }
     printPDF(doc, file.getName, numCopies)

--- a/src/main/scala/Printer.scala
+++ b/src/main/scala/Printer.scala
@@ -70,31 +70,27 @@ object Printer {
       throw new PrinterException(file.getName + " is not a pdf")
     val pdf = PDDocument.load(file)
     val pdfRenderer = new PDFRenderer(pdf)
-    
+
     val bims = for (page <- 0 until pdf.getNumberOfPages) yield {
-      pdfRenderer.renderImageWithDPI(page, 300, ImageType.RGB)
+      pdfRenderer.renderImageWithDPI(page, 500, ImageType.RGB)
     }
 
-
     val doc = new PDDocument()
+    val pageBox = pdf.getPage(0).getCropBox
     for ((bim, index) <- bims.zipWithIndex) {
-      //Save page test
+      //Save image as png test
       //ImageIOUtil.writeImage(bim, file.getName.dropRight(4) + "-" + (index+1) + ".png", 300)
 
-      val page = new PDPage(PDRectangle.A4)
+      val page = new PDPage(pageBox)
       doc.addPage(page)
       val pdImageXObject = LosslessFactory.createFromImage(doc, bim)
 
-
-      println(s"Height: ${page.getCropBox.getHeight}")
-      println(s"Width: ${page.getCropBox.getWidth}")
-
-      // Second bool is compression. Remove if bad quality
-      val contentStream = new PDPageContentStream(doc, page, PDPageContentStream.AppendMode.OVERWRITE, true)
-      contentStream.drawImage(pdImageXObject, 0, 0, page.getCropBox.getWidth, page.getCropBox.getHeight)
+      // Second bool is compression. Set to false for increased quality
+      val contentStream = new PDPageContentStream(doc, page, PDPageContentStream.AppendMode.OVERWRITE, false)
+      contentStream.drawImage(pdImageXObject, 0, 0, pageBox.getWidth, pageBox.getHeight)
       contentStream.close()
     }
-    // Save pdf test
+    // Save finished pdf test
     //doc.save("test.pdf")
 
     printPDF(doc, file.getName, numCopies)

--- a/src/main/scala/Printer.scala
+++ b/src/main/scala/Printer.scala
@@ -63,13 +63,13 @@ object Printer {
     
     val doc = new PDDocument()
     for (bim <- bims) {
-      val page = new PDPage()
+      val page = new PDPage(PDRectangle.A4)
       doc.addPage(page)
       val pdImageXObject = LosslessFactory.createFromImage(doc, bim, 300)
       
       // Second bool is compression. Remove if bad quality
       val contentStream = new PDPageContentStream(doc, page, false, true) 
-      contentStream.drawImage(pdImageXObject, 0, 0)
+      contentStream.drawImage(pdImageXObject, 0, page.getCropBox().getHeight())
       contentStream.close()
     }
     printPDF(doc, numCopies)

--- a/src/main/scala/Printer.scala
+++ b/src/main/scala/Printer.scala
@@ -3,6 +3,7 @@ import java.awt.print.{PrinterException, PrinterJob}
 import javax.print.attribute.HashPrintRequestAttributeSet
 import javax.print.attribute.standard.{Chromaticity, Copies, JobName, PageRanges, Sides}
 
+import org.apache.pdfbox.pdmodel.common.PDRectangle
 import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory
 import org.apache.pdfbox.pdmodel.{PDDocument, PDPage, PDPageContentStream}
 import org.apache.pdfbox.printing.PDFPageable
@@ -83,7 +84,7 @@ object Printer {
       
       // Second bool is compression. Remove if bad quality
       val contentStream = new PDPageContentStream(doc, page, PDPageContentStream.AppendMode.OVERWRITE, true)
-      contentStream.drawImage(pdImageXObject, 0, 0)
+      contentStream.drawImage(pdImageXObject, 0, page.getCropBox.getHeight)
       contentStream.close()
     }
     printPDF(doc, file.getName, numCopies)

--- a/src/main/scala/Printer.scala
+++ b/src/main/scala/Printer.scala
@@ -1,15 +1,9 @@
 import java.io.File
-import java.awt.print.PrinterJob
-import java.awt.print.PrinterException
+import java.awt.print.{PrinterJob, PrinterException}
 
 import javax.print.PrintService
-import javax.print.attribute.HashPrintRequestAttributeSet
-import javax.print.attribute.PrintRequestAttributeSet
-import javax.print.attribute.standard.PageRanges
-import javax.print.attribute.standard.Sides
-import javax.print.attribute.standard.Copies
-import javax.print.attribute.standard.JobName
-import javax.print.attribute.standard.Chromaticity
+import javax.print.attribute.{HashPrintRequestAttributeSet, PrintRequestAttributeSet}
+import javax.print.attribute.standard.{PageRanges, Sides, Copies, JobName, Chromaticity}
 
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.printing.PDFPageable
@@ -46,6 +40,21 @@ object Printer {
     pdf.close()
   }
 
+  /** Prints a pdf file to the standard printer as an image with the following settings:
+   *  - job name is same as product
+   *  - all pages
+   *  - double-sided (long edge)
+   *  - in color
+   *
+   *  @param file the pdf file to print
+   *  @param numCopies number of printed copies of the file
+   */
+  def printPDFasImage(file: File, numCopies: Int): Unit = {
+    if (!file.getName().endsWith("pdf")) 
+      throw new PrinterException(file.getName() + " is not a pdf")
+    
+  }
+  
   /** Prints one copy of all pdfs in a directory
    *
    *  @param dir the directory with pdfs to print

--- a/src/main/scala/Printer.scala
+++ b/src/main/scala/Printer.scala
@@ -5,10 +5,6 @@ import javax.print.PrintService
 import javax.print.attribute.{HashPrintRequestAttributeSet, PrintRequestAttributeSet}
 import javax.print.attribute.standard.{PageRanges, Sides, Copies, JobName, Chromaticity}
 
-import java.awt.Graphics;
-import java.awt.image.BufferedImage;
-import java.awt.print.{Printable, PageFormat}
-
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.printing.PDFPageable
 

--- a/src/main/scala/Printer.scala
+++ b/src/main/scala/Printer.scala
@@ -66,7 +66,9 @@ object Printer {
       val page = new PDPage()
       doc.addPage(page)
       val pdImageXObject = LosslessFactory.createFromImage(doc, bim, 300)
-      val contentStream = new PDPageContentStream(doc, page, true, true)
+      
+      // Second bool is compression. Remove if bad quality
+      val contentStream = new PDPageContentStream(doc, page, false, true) 
       contentStream.drawImage(pdImageXObject, 0, 0)
       contentStream.close()
     }

--- a/src/main/scala/Printer.scala
+++ b/src/main/scala/Printer.scala
@@ -71,8 +71,9 @@ object Printer {
     
     val bims = for (page <- 0 until pdf.getNumberOfPages) yield {
       pdfRenderer.renderImageWithDPI(page, 300, ImageType.RGB)
-      //Save page:
-      //ImageIOUtil.writeImage(bim, pdfFilename + "-" + (page+1) + ".png", 300)
+      
+      //Save page test
+      ImageIOUtil.writeImage(bim, pdfFilename + "-" + (page+1) + ".png", 300)
     }
     
     val doc = new PDDocument()


### PR DESCRIPTION
Merging image printing to master. This means that all pdf pages are converted to images before being added to a new pdf which in turn is printed. This approach was taken to fix (the annoying) issue #27 where some full-image pages were blank. This only happend for some products but for ease-of-use this is done for all printings. 

Issue #34 is also fixed with this pull request, which means that the product family TDS is printed when no product specific TDS exists.

With this the version is updated to 1.0.6.